### PR TITLE
fix not copy directories in full mode, #516

### DIFF
--- a/lib/command/build.js
+++ b/lib/command/build.js
@@ -679,7 +679,7 @@ build.copy_directories = function(options, callback) {
     return callback(null);
   }
 
-  if (file) {
+  if (build_type == 'dir' && file) {
     // only copy the changed file
     file = node_path.relative(cwd, file);
     self.copy(cwd, to, file, function(err) {


### PR DESCRIPTION
It's my fault introduced by #516.

If `file` exists, the build type may be `dir` or `full`.