### PR TITLE
only rebuild those affected entries

### DIFF
--- a/lib/command/build.js
+++ b/lib/command/build.js
@@ -77,7 +77,7 @@ build.prepare_build_type = function(options, callback){
     }).indexOf(file) > -1;
   }
 
-  function isJs() {
+  function isMod() {
     return /\.js$/.test(file);
   }
 
@@ -87,7 +87,7 @@ build.prepare_build_type = function(options, callback){
     options.build_type = 'css';
   }else if(build._in_directories(options, file)){
     options.build_type = 'dir';
-  }else if(isJs()) {
+  }else if(isMod()) {
     options.build_type = 'mod';
   }else{
     options.build_type = 'full';

--- a/lib/command/build.js
+++ b/lib/command/build.js
@@ -77,12 +77,18 @@ build.prepare_build_type = function(options, callback){
     }).indexOf(file) > -1;
   }
 
+  function isJs() {
+    return /\.js$/.test(file);
+  }
+
   if(hasFile(entries)){
     options.build_type = 'js';
   }else if(hasFile(csses)){
     options.build_type = 'css';
   }else if(build._in_directories(options, file)){
     options.build_type = 'dir';
+  }else if(isJs()) {
+    options.build_type = 'mod';
   }else{
     options.build_type = 'full';
   }
@@ -490,7 +496,7 @@ build.build_modules = function(options, callback) {
   var pkg = options.pkg;
   var build_type = options.build_type;
 
-  if(!this._is_type(build_type, 'js')){
+  if(!this._is_type(build_type, 'js') && !this._is_type(build_type, 'mod')) {
     return callback(null);
   }
 
@@ -521,6 +527,7 @@ build.build_modules = function(options, callback) {
       cwd: cwd,
       targetVersion: pkg.version,
       pkg: options.pkg,
+      changedFile: options.file,
       loaders: loaders
     })
     .on('warn', function (warn) {
@@ -528,6 +535,10 @@ build.build_modules = function(options, callback) {
     })
     .parse(from, function (err, content) {
       if (err) {
+        if (err.code == 'ENOTNEEDBUILD') {
+          self.logger.debug('Not need build:', entry);
+          return done(null);
+        }
         return done(err);
       }
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "loggie": "^0.1.8",
     "make-array": "^0.1.1",
     "mix2": "^1.0.0",
-    "neuron-builder": "^4.0.0",
+    "cortex-neuron-builder": "^4.1.0",
     "neuron-graph": "^1.0.0",
     "neuronjs": "^8.3.0",
     "neuropil": "^7.0.0",


### PR DESCRIPTION
As #514 describes,

>
Add another build type, like mod. It may require neuron-builder to accept the changed file as an argument. So that it can reject unnecessary build. If users only modify a file in mod/, entries that do not depend on it will not be re-built.

This MR depends on [another MR](https://github.com/cortexjs/cortex-neuron-builder/pull/1) in `cortex-neuron-builder` project.

And I have to admit that function `isMod` is too rude. If reading from somewhere in `cortex.json`, say field `mods`, will be more flexible. But it may lead to a series of modifications.