### PR TITLE
optimize the error message

### DIFF
--- a/lib/command/build.js
+++ b/lib/command/build.js
@@ -716,7 +716,7 @@ build.copy_directories = function(options, callback) {
       if (err && err.code === 'SRC_NOT_FOUND') {
         err = {
           code: 'DIR_NOT_FOUND',
-          message: '`directories.' + name + '.' + dir + '` is defined in cortex.json, but not found.',
+          message: '`directories.' + name + ':' + dir + '` is defined in cortex.json, but not found.',
           data: {
             name: name,
             dir: dir


### PR DESCRIPTION
```
// before
ERR! `directories.html.html` is defined in cortex.json, but not found.
// after
ERR! `directories.html:html` is defined in cortex.json, but not found.
```

The colon seems to be more appropriate.
