### PR TITLE
support to specify another file as `cortex.json`

### DIFF
--- a/lib/command/build.js
+++ b/lib/command/build.js
@@ -140,7 +140,14 @@ build.simplely_read_cortex_json = function (options, callback) {
 
 build.read_cortex_json = function(options, callback) {
   var self = this;
-  cortex_json.extra(options.cwd, function (err, pkg) {
+
+  var opts = {};
+  var jsonfile = options.jsonfile;
+  if (jsonfile) {
+    opts.file = jsonfile;
+  }
+
+  cortex_json.extra(options.cwd, opts, function (err, pkg) {
     if (err) {
       return callback(err);
     }

--- a/lib/command/watch.js
+++ b/lib/command/watch.js
@@ -215,6 +215,11 @@ watch._rebuild = function(options, cwd, init) {
       '--cwd', cwd
     ];
 
+    var jsonfile = options.jsonfile;
+    if (jsonfile) {
+        argv.push('--jsonfile', jsonfile);
+    }
+
     var file = options.file;
     if(file){
       argv.push('--file', file);

--- a/lib/option/build.js
+++ b/lib/option/build.js
@@ -22,6 +22,11 @@ exports.options = {
     type: node_path
   },
 
+  jsonfile: {
+    type: node_path,
+    info: 'the json file used as cortex.json'
+  },
+
   prebuild: {
     enumerable: false,
     type: Boolean,

--- a/lib/option/watch.js
+++ b/lib/option/watch.js
@@ -42,6 +42,11 @@ exports.options = {
     }
   },
 
+  jsonfile: {
+    type: node_path,
+    info: 'the json file used as cortex.json'
+  },
+
   stop: {
     type: Boolean,
     info: 'with "--stop", cortex will remove directories out of the watching list.',


### PR DESCRIPTION
Depend on [read-cortex-json#31](https://github.com/cortexjs/read-cortex-json/issues/31).
