### PR TITLE
fix #519

### DIFF
--- a/lib/command/build.js
+++ b/lib/command/build.js
@@ -18,6 +18,7 @@ var ngraph      = require('neuron-graph');
 var neuron      = require('neuronjs');
 var util        = require('util');
 var MD5         = require('MD5');
+var minimatch        = require('minimatch');
 
 // @param {Object} options
 //      see ./lib/option/build.js for details
@@ -72,9 +73,12 @@ build.prepare_build_type = function(options, callback){
   var file = options.file;
 
   function hasFile(list){
-    return list.map(function(rel){
-      return node_path.join(options.cwd, rel);
-    }).indexOf(file) > -1;
+    if (!file) { return false; }
+
+    var rel = node_path.relative(options.cwd, file);
+    return (list || []).some(function(value) {
+      return minimatch(rel, value);
+    });
   }
 
   function isMod() {

--- a/lib/command/build.js
+++ b/lib/command/build.js
@@ -38,7 +38,6 @@ build.run = function(options, callback) {
       'server_link'
     ] : [
       'read_cortex_json',
-      'clean_cortex_json',
       'read_cortex_config_js',
       'prepare_build_type',
       'run_preinstall_script',
@@ -46,6 +45,7 @@ build.run = function(options, callback) {
       // #478
       // `cortex.main` and many other files might have not been generated before `cortex.scripts`
       // so, we clean cortex_json
+      'clean_cortex_json',
       'build_process',
       'server_link',
       'run_postbuild_script',

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ignore": "^2.2.14",
     "loggie": "^0.1.8",
     "make-array": "^0.1.1",
+    "minimatch": "^3.0.0",
     "mix2": "^1.0.0",
     "cortex-neuron-builder": "^4.1.0",
     "neuron-graph": "^1.0.0",


### PR DESCRIPTION
Fix #519. Solved the loop of build steps by changing the logic of determining build type.

If determining by files searching, `prepare_build_type` need to depend on `clean_cortex_json`.
If determining by glob matching, `prepare_build_type` can DO NOT depend on `clean_cortex_json`. 
